### PR TITLE
client: Consider image name parameter

### DIFF
--- a/client.go
+++ b/client.go
@@ -184,7 +184,9 @@ func (p *Prometheus) BuildContainerFile(dockerfilePath string, imageName string)
 	id, _, err := imagebuildah.BuildDockerfiles(
 		context.Background(),
 		p.Store,
-		define.BuildOptions{},
+		define.BuildOptions{
+            Output: imageName,
+        },
 		dockerfilePath,
 	)
 	if err != nil {


### PR DESCRIPTION
This PR makes use of the previously unused `imageName` parameter in `BuildContainerFile` to give a name to the image.
