### PR TITLE
feat/ci: bump actions/setup-go to v5

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,9 +15,9 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.19
+        go-version: 1.21
 
     - name: Install build dependencies
       run: |


### PR DESCRIPTION
## Changes

- Bump `actions/setup-go` to `v5` (Node 20).
- Set the `go` version to 1.21.