### PR TITLE
feat: return manifest digest

### DIFF
--- a/client.go
+++ b/client.go
@@ -182,13 +182,6 @@ func (p *Prometheus) pullImage(imageName, dstName string, progressCh chan types.
 			return
 		}
 
-		// here we remove the 'sha256:' prefix from the digest, so we don't have
-		// to deal with it later
-		manifest.Config.Digest = manifest.Config.Digest[7:]
-		for i := range manifest.Layers {
-			manifest.Layers[i].Digest = manifest.Layers[i].Digest[7:]
-		}
-
 		manifestCh <- manifest
 	}()
 

--- a/client.go
+++ b/client.go
@@ -188,15 +188,15 @@ func (p *Prometheus) pullImage(imageName, dstName string, progressCh chan types.
 	return nil
 }
 
-/* GetImageByDigest returns an image from the Prometheus store by its digest. */
-func (p *Prometheus) GetImageByDigest(digest string) (cstorage.Image, error) {
+/* GetImageById returns an image from the Prometheus store by its ID. */
+func (p *Prometheus) GetImageById(id string) (cstorage.Image, error) {
 	images, err := p.Store.Images()
 	if err != nil {
 		return cstorage.Image{}, err
 	}
 
 	for _, img := range images {
-		if img.ID == digest {
+		if img.ID == id {
 			return img, nil
 		}
 	}
@@ -205,16 +205,15 @@ func (p *Prometheus) GetImageByDigest(digest string) (cstorage.Image, error) {
 	return cstorage.Image{}, err
 }
 
-/* DoesImageExist checks if an image exists in the Prometheus store by its
- * digest. It returns a boolean indicating if the image exists and an error
- * if any. */
-func (p *Prometheus) DoesImageExist(digest string) (bool, error) {
-	image, err := p.GetImageByDigest(digest)
+/* DoesImageExist checks if an image exists in the Prometheus store by its ID.
+ * It returns a boolean indicating if the image exists and an error if any. */
+func (p *Prometheus) DoesImageExist(id string) (bool, error) {
+	image, err := p.GetImageById(id)
 	if err != nil {
 		return false, err
 	}
 
-	if image.ID == digest {
+	if image.ID == id {
 		return true, nil
 	}
 
@@ -259,7 +258,7 @@ func (p *Prometheus) BuildContainerFile(dockerfilePath string, imageName string)
 		return cstorage.Image{}, err
 	}
 
-	image, err := p.GetImageByDigest(id)
+	image, err := p.GetImageById(id)
 	if err != nil {
 		return cstorage.Image{}, err
 	}

--- a/structs.go
+++ b/structs.go
@@ -11,7 +11,10 @@ package prometheus
 		and Albius.
 */
 
-import cstorage "github.com/containers/storage"
+import (
+    cstorage "github.com/containers/storage"
+    digest "github.com/opencontainers/go-digest"
+)
 
 type Prometheus struct {
 	Store  cstorage.Store
@@ -26,9 +29,9 @@ type OciManifest struct {
 }
 
 type OciManifestConfig struct {
-	MediaType string `json:"mediaType"`
-	Size      int    `json:"size"`
-	Digest    string `json:"digest"`
+	MediaType string        `json:"mediaType"`
+	Size      int           `json:"size"`
+	Digest    digest.Digest `json:"digest"`
 }
 
 type PrometheusConfig struct {

--- a/tests/pull_image_test.go
+++ b/tests/pull_image_test.go
@@ -32,7 +32,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestPullImage(t *testing.T) {
-	image, err := pmt.PullImage("docker.io/library/alpine:latest", "my-alpine")
+	image, digest, err := pmt.PullImage("docker.io/library/alpine:latest", "my-alpine")
 	if err != nil {
 		t.Fatalf("error pulling image: %v", err)
 	}
@@ -41,8 +41,8 @@ func TestPullImage(t *testing.T) {
 		t.Fatal("image is nil")
 	}
 
-	if image.Config.Digest == "" {
-		t.Fatal("image config digest is empty")
+	if digest == "" {
+		t.Fatal("image digest is empty")
 	}
 
 	if image.Config.Size == 0 {

--- a/tests/pull_image_test.go
+++ b/tests/pull_image_test.go
@@ -45,6 +45,10 @@ func TestPullImage(t *testing.T) {
 		t.Fatal("image digest is empty")
 	}
 
+	if image.Config.Digest == "" {
+		t.Fatal("image config digest is empty")
+	}
+
 	if image.Config.Size == 0 {
 		t.Fatal("image config size is 0")
 	}


### PR DESCRIPTION
Currently, Prometheus incorrectly uses the *image ID* as the *digest* (ref: [What's the difference between a Docker image's Image ID and its Digest?](https://stackoverflow.com/questions/56364643/whats-the-difference-between-a-docker-images-image-id-and-its-digest)). The actual manifest digest is never returned, causing inconsistencies with ABRoot.

This PR addresses the issue by:

+ Returning the manifest digest
+ Using the `digest.Digest` type to handle digest validation and formatting
+ Preserving the `sha256:` prefix as it's part of the standard digest format